### PR TITLE
Add tsconfig.json for development with vscode

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "./tsconfig.dev"
+}


### PR DESCRIPTION
VSCodeにはtsの設定ファイルとして`tsconfig.json`以外を設定できないため、VSCode用にそれを用意した